### PR TITLE
Adjust websdr URLs to decode CW activations

### DIFF
--- a/js/display-funcs.js
+++ b/js/display-funcs.js
@@ -229,7 +229,7 @@ function getTooltipText(s) {
     ttt += "<br/>";
 
     // Frequency & band
-    const urlForFreq = getURLForFrequency(s.freq);
+    const urlForFreq = getURLForFrequency(s.freq, s.mode);
     if (urlForFreq != null) {
         ttt += "<a href='" + urlForFreq + "' target='_blank'>";
     }


### PR DESCRIPTION
Tested by overwriting function definitions in my browser.
Tested with http://websdr1.kfsdr.com:8901/ and http://websdr.k3fef.com:8901/.

This could be extended to USB/LSB, but as that will require some more testing, I am leaving that for a separate feature.

