### PR TITLE
Use WWBOTA Server-Side Events API for spots

### DIFF
--- a/js/globals.js
+++ b/js/globals.js
@@ -65,6 +65,7 @@ let wabGrid;
 let cqZones;
 let ituZones;
 let lastSeenSOTAAPIEpoch = "";
+let eventSourceWWBOTAAPI = null;
 let currentPopupSpotUID = null;
 let currentLineToSpot = null;
 let alreadyMovedMap = false;

--- a/js/utility-funcs.js
+++ b/js/utility-funcs.js
@@ -519,3 +519,14 @@ function enableWABGrid(show) {
         }
     }
 }
+
+// Debounce calls to function
+function debounce(func, delay) {
+    let timeout;
+    return function (...args) {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => {
+            func.apply(this, args);
+        }, delay);
+    };
+}


### PR DESCRIPTION
This uses SSE for receiving spots from the WWBOTA API, meaning low latency of spots and reducing bandwidth.

With SSE, each spot is sent as a event in same format as standard API, rather than a list of spots. Debounce is used to avoid multiple map updates on intial connection when last 2 hours of spots are sent.